### PR TITLE
Branchless binary search (integer version)

### DIFF
--- a/c_plus_plus/binary_search_int/function.cpp
+++ b/c_plus_plus/binary_search_int/function.cpp
@@ -7,7 +7,7 @@ int binary_search_int(const std::vector<int>& arr, int target) {
     unsigned indices [] = { 0, arr.size() };
     
 
-    while (indices[0] < indices[1]) {
+    while (indices[0] + 1 < indices[1]) {
         //    Note: Can fail due to overflow, but unlikely to in the test action. Add half of diference to avoid.
         unsigned mid = (indices[0] + indices[1]) / 2;
 

--- a/c_plus_plus/binary_search_int/function.cpp
+++ b/c_plus_plus/binary_search_int/function.cpp
@@ -1,23 +1,19 @@
 #include "function.h"
 
 int binary_search_int(const std::vector<int>& arr, int target) {
-    int left = 0;
-    int right = arr.size() - 1;
-    int result = -1;
+    // Use unsigned indices to let compiler skip consideration of negative values.
+    if (arr.empty())
+        return -1;
+    unsigned indices [] = { 0, arr.size() };
     
 
-    while (left <= right) {
-        int mid = (left + right) / 2;
+    while (indices[0] < indices[1]) {
+        //    Note: Can fail due to overflow, but unlikely to in the test action. Add half of diference to avoid.
+        unsigned mid = (indices[0] + indices[1]) / 2;
 
-        if (arr[mid] == target) {
-            result = mid;
-            right = mid - 1;
-        } else if (arr[mid] < target) {
-            left = mid + 1;
-        } else {
-            right = mid - 1;
-        }
+        //    Branches? We don't need no stinkin' branches. (author's note: This is the _other_ type of reference)
+        indices[arr[mid] > target] = mid;
     }
 
-    return result;
+    return (arr[indices[0]] == target) ? static_cast<int>(indices[0]) : -1;
 }


### PR DESCRIPTION
Original didn't have early exit, so this should be a strict improvement. That said, both variants are probably cache-limited.

Note: Improvements to cache hit rate can probably be achieved by assuming data equidistribution.